### PR TITLE
fix typo s/enterface/interface/

### DIFF
--- a/templates/common/listen.conf.erb
+++ b/templates/common/listen.conf.erb
@@ -67,7 +67,7 @@ listen {
   #  If your system does not support this feature, you will
   #  get an error if you try to use it.
   #
-  interface = <%= @enterface %>
+  interface = <%= @interface %>
 <%- end %>
 <%- if @clients %>
   #  Per-socket lists of clients.  This is a very useful feature.


### PR DESCRIPTION
Hi James

As I'm nearing production I have some branches that I would like to push. This first one contains almost nothing. My plural "bugfixes" turned out to be singular.

Would it be ok for you if I start pushing lots of branches in a somewhat logical fashion over the next couple of weeks?

I think yours is the most complete module out there and I'd rather not get all forked up on this.

cheers
Lucas
