### PR TITLE
use user/group from params in template

### DIFF
--- a/templates/debian/radiusd.conf.erb
+++ b/templates/debian/radiusd.conf.erb
@@ -164,8 +164,8 @@ pidfile = ${run_dir}/${name}.pid
 #  It will join all groups where "user" is a member.  This can allow
 #  for some finer-grained access controls.
 #
-user = freerad
-group = freerad
+user = <%= scope.lookupvar('freeradius::params::radius')['uid'] %>
+group = <%= scope.lookupvar('freeradius::params::radius')['gid'] %>
 
 #  max_request_time: The maximum time (in seconds) to handle a request.
 #


### PR DESCRIPTION
Just for consistency since different os implementations may want to change the user/group

I stumbled over this when experimenting with the params on different archs.
